### PR TITLE
FuelType Enum values corrected

### DIFF
--- a/models.py
+++ b/models.py
@@ -5,8 +5,8 @@ import enum
 
 
 class FuelType(str, enum.Enum):
-    petrol = "Petrol"
-    diesel = "Diesel"
+    Petrol = "Petrol"
+    Diesel = "Diesel"
 
 
 class CarInfo(Base):


### PR DESCRIPTION
In sql table creation enum values used in fueltype are Petrol and Diesel. But here the values are mapped to petrol and diesel starting with lower case letters .This gives error while making a post or put request to api